### PR TITLE
Fix  The PNG > BRUH won't work

### DIFF
--- a/main.rs
+++ b/main.rs
@@ -14,6 +14,8 @@ use std::{
     io::Write,
     path::PathBuf,
 };
+use std::fs::File;
+use std::io::Result;
 
 use skia_safe::{
     AlphaType, Color4f, ColorType, EncodedImageFormat, ImageInfo, Paint, Rect, Surface,
@@ -30,6 +32,7 @@ fn vec_to_u32_ne(bytes: &[u8]) -> u32 {
 }
 
 fn png_to_bruh(path: PathBuf) -> Result<(), std::io::Error> {
+    
     let img = image::open(&path).expect("File not found!");
     let mut str = String::new();
     let mut last_line = 0;
@@ -56,6 +59,7 @@ fn png_to_bruh(path: PathBuf) -> Result<(), std::io::Error> {
         let height_bytes: [u8; 4] = height.to_ne_bytes();
         let width_bytes: [u8; 4] = width.to_ne_bytes();
         let path_to_bruh = path_str.replace(".png", ".bruh");
+        File::create(path_to_bruh)?;
 
         let mut file = OpenOptions::new()
             .write(true)

--- a/main.rs
+++ b/main.rs
@@ -15,7 +15,6 @@ use std::{
     path::PathBuf,
 };
 use std::fs::File;
-use std::io::Result;
 
 use skia_safe::{
     AlphaType, Color4f, ColorType, EncodedImageFormat, ImageInfo, Paint, Rect, Surface,


### PR DESCRIPTION
i only fixed the issue:
⚠ The PNG > BRUH won't work unless you have the same file (i.e. image.png) but with the .bruh extension (i.e. image.bruh). What do you have to do? Create an empty file called image.bruh.



||(i haven't tested it out yet because my windows laptop has issues with rust somehow)||

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handling to ensure the output file is properly created or truncated before writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->